### PR TITLE
Udp updates and improved sensor callback trick ;)

### DIFF
--- a/config.js
+++ b/config.js
@@ -10,8 +10,14 @@ var config = {
         reminderIntervalMinutes: 10,
         // Indicates if all the events, methods, etc, will return seconds
         // instead of minutes for reporting time, also the config values will
-        // be considered as seconds instead of minutes. Useful for testing. 
-        useSecondsInsteadOfMinutes: true,
+        // be considered as seconds instead of minutes. Useful for testing.
+        useSecondsInsteadOfMinutes: false,
+        // Slack config
         slackToken: '',
-        slackChannelName: 'general'
+        slackChannelName: 'general',
+        // Indicates if udp updates with accelerometer values should be sent
+        sendUdpUpdates: true,
+        udpPort: 47624,
+        // If this IP is not present (undefined or null), broadcast ip will be used
+        udpIpAddress: null
 };

--- a/washingMonitor.js
+++ b/washingMonitor.js
@@ -1,5 +1,5 @@
-function washingMonitorSensorCallback(){
-    washingMonitor.sensorCallbackFn();
+function washingMonitorSensorCallback(x, y, z){
+    washingMonitor.sensorCallbackFn(x, y, z);
 }
 
 (function (washingMonitor){
@@ -39,11 +39,7 @@ function washingMonitorSensorCallback(){
         if (monitor){
             console.log("WashingMonitor already created, returning existing instance.");
             return monitor;
-        }
-
-        /* Options
-        useSecondsForTime
-        */
+        }    
 
         var myMonitor = monitor = {};
 
@@ -89,7 +85,7 @@ function washingMonitorSensorCallback(){
         myMonitor.hasFinished = function (){
             return hasFinished;
         };
-        
+
         myMonitor.getStartTime = function (){
             return startTime;
         };
@@ -112,7 +108,7 @@ function washingMonitorSensorCallback(){
             washingMonitor.sensorCallbackFn = washingStarted;
         }
 
-        function washingStarted(){
+        function washingStarted(x, y, z){
             // We clear the washingStart interval
             clearInterval(timeOutHandler);
 
@@ -120,7 +116,7 @@ function washingMonitorSensorCallback(){
 
             // Now the machine is washing, on each movement we reset the counter
             washingMonitor.sensorCallbackFn = washingMovementDetected;
-            washingMovementDetected();
+            washingMovementDetected(x, y, z);
 
             notifyEvent(washingMonitor.eventTypes.washingStarted);
         };
@@ -129,7 +125,7 @@ function washingMonitorSensorCallback(){
             notifyEvent(washingMonitor.eventTypes.washingNotStarted, washingNotStartedCounter++);
         }
 
-        function washingMovementDetected(){
+        function washingMovementDetected(x, y, z){
             // Resets the laundryFinished timers, so it keeps counting
             if (timeOutHandler) clearTimeout(timeOutHandler);
             timeOutHandler = setTimeout(washingFinished, convertToMs(options.washingThresholdMinutes));
@@ -138,7 +134,7 @@ function washingMonitorSensorCallback(){
             // when it stopped moving
             finishTime = new Date();
 
-            notifyEvent(washingMonitor.eventTypes.washingMovement, getWashingDurationInMinutes());
+            notifyEvent(washingMonitor.eventTypes.washingMovement, getWashingDurationInMinutes(), x, y, z);
         }
 
         function washingFinished(){


### PR DESCRIPTION
- Improved sensor callback trick so the var that holds the real callback to call is internal to the monitor closure. This also put us closer to decouple the monitor from the sensor, as the monitor.fireSensorCallback could be called from outside on the monitor instance.
  And also put us closer to have two monitors alive (useless anyway :P)
- Also added function to check movement threshold, dummy implementation for now.

Please @mc15 check and merge ;)
